### PR TITLE
Add support for `amount_fen` (integer cents) with validation and deprecate yuan `amount`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ ESM、TypeScript、全支付方式支持
 - ✅ 双签名验证（新公钥 + 平台证书）
 - ✅ 内置调试模式
 - ✅ 最小依赖（@peculiar/x509、ofetch）
-- ✅ 自动金额格式化（元转分）
+- ✅ 支持分单位直传（`amount_fen`），并兼容旧的元单位字段
 - ✅ 完善的测试覆盖
 - ✅ demo 服务 - 基于 hono 的轻量级 web 应用，用于本地测试和调试
 - ✅ 框架集成 - 提供 Next.js 和 Nuxt.js 的使用示例
@@ -56,7 +56,7 @@ const wechat = new WeChatPay({
 const payment = await wechat.native.create({
   out_trade_no: 'order-123',
   description: '会员订阅',
-  amount: 99.00  // 自动转换为分（9900）
+  amount_fen: 9900  // 推荐：直接使用分，避免浮点误差
 });
 
 console.log('二维码链接:', payment.code_url);

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ ESM、TypeScript、全支付方式支持
 - ✅ 双签名验证（新公钥 + 平台证书）
 - ✅ 内置调试模式
 - ✅ 最小依赖（@peculiar/x509、ofetch）
-- ✅ 支持分单位直传（`amount_fen`），并兼容旧的元单位字段
+- ✅ 支持分单位直传（`amount_cents`），并兼容旧的元单位字段
 - ✅ 完善的测试覆盖
 - ✅ demo 服务 - 基于 hono 的轻量级 web 应用，用于本地测试和调试
 - ✅ 框架集成 - 提供 Next.js 和 Nuxt.js 的使用示例
@@ -56,7 +56,7 @@ const wechat = new WeChatPay({
 const payment = await wechat.native.create({
   out_trade_no: 'order-123',
   description: '会员订阅',
-  amount_fen: 9900  // 推荐：直接使用分，避免浮点误差
+  amount_cents: 9900  // 推荐：直接使用分，避免浮点误差
 });
 
 console.log('二维码链接:', payment.code_url);

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -174,8 +174,10 @@ const result = await wechat.native.refund(params: RefundParams);
 | `reason` | `string` | | 退款原因 |
 | `notify_url` | `string` | | 退款结果回调地址 |
 | `funds_account` | `string` | | 退款资金来源 |
-| `refund` | `number` | ✅ | 退款金额，单位：元 |
-| `total` | `number` | ✅ | 原订单金额，单位：元 |
+| `refund_fen` | `number` | ✅（推荐） | 退款金额，单位：分，必须为整数 |
+| `total_fen` | `number` | ✅（推荐） | 原订单金额，单位：分，必须为整数 |
+| `refund` | `number` | ⚠️ Deprecated | 退款金额，单位：元（兼容字段） |
+| `total` | `number` | ⚠️ Deprecated | 原订单金额，单位：元（兼容字段） |
 | `currency` | `string` | | 货币类型 |
 
 #### 返回值

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -80,7 +80,8 @@ const result = await wechat.native.create(params: CreateNativePaymentParams);
 |-----|------|-----|------|
 | `out_trade_no` | `string` | ✅ | 商户订单号，6-32 位字符 |
 | `description` | `string` | ✅ | 商品描述 |
-| `amount` | `number` | ✅ | 订单金额，单位：元 |
+| `amount_fen` | `number` | ✅（推荐） | 订单金额，单位：分，必须为整数 |
+| `amount` | `number` | ⚠️ Deprecated | 订单金额，单位：元（兼容字段） |
 | `currency` | `string` | | 货币类型，默认 CNY |
 | `payer_client_ip` | `string` | | 用户终端 IP |
 | `time_expire` | `string` | | 过期时间，RFC 3339 格式 |
@@ -288,7 +289,8 @@ interface QueryCombineOrderResult {
     transaction_id?: string;
     out_trade_no: string;
     amount: {
-      total_amount: number;
+      total_amount_fen?: number;
+      total_amount?: number; // deprecated
       currency?: string;
     };
   }>;

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -80,7 +80,7 @@ const result = await wechat.native.create(params: CreateNativePaymentParams);
 |-----|------|-----|------|
 | `out_trade_no` | `string` | ✅ | 商户订单号，6-32 位字符 |
 | `description` | `string` | ✅ | 商品描述 |
-| `amount_fen` | `number` | ✅（推荐） | 订单金额，单位：分，必须为整数 |
+| `amount_cents` | `number` | ✅（推荐） | 订单金额，单位：分，必须为整数 |
 | `amount` | `number` | ⚠️ Deprecated | 订单金额，单位：元（兼容字段） |
 | `currency` | `string` | | 货币类型，默认 CNY |
 | `payer_client_ip` | `string` | | 用户终端 IP |
@@ -174,8 +174,8 @@ const result = await wechat.native.refund(params: RefundParams);
 | `reason` | `string` | | 退款原因 |
 | `notify_url` | `string` | | 退款结果回调地址 |
 | `funds_account` | `string` | | 退款资金来源 |
-| `refund_fen` | `number` | ✅（推荐） | 退款金额，单位：分，必须为整数 |
-| `total_fen` | `number` | ✅（推荐） | 原订单金额，单位：分，必须为整数 |
+| `refund_cents` | `number` | ✅（推荐） | 退款金额，单位：分，必须为整数 |
+| `total_cents` | `number` | ✅（推荐） | 原订单金额，单位：分，必须为整数 |
 | `refund` | `number` | ⚠️ Deprecated | 退款金额，单位：元（兼容字段） |
 | `total` | `number` | ⚠️ Deprecated | 原订单金额，单位：元（兼容字段） |
 | `currency` | `string` | | 货币类型 |
@@ -291,7 +291,7 @@ interface QueryCombineOrderResult {
     transaction_id?: string;
     out_trade_no: string;
     amount: {
-      total_amount_fen?: number;
+      total_amount_cents?: number;
       total_amount?: number; // deprecated
       currency?: string;
     };

--- a/docs/native-payment.md
+++ b/docs/native-payment.md
@@ -26,7 +26,8 @@ Native 支付是指商户系统生成支付二维码，用户使用微信"扫一
 const payment = await wechat.native.create({
   out_trade_no: 'order-123',           // 商户订单号（必填，6-32位）
   description: '商品描述',              // 商品描述（必填）
-  amount: 99.00,                       // 金额，单位元（必填）
+  amount_fen: 9900,                    // 金额，单位分（推荐）
+  // amount: 99.00,                    // 已废弃：单位元，兼容保留
   currency: 'CNY',                     // 货币类型（可选，默认 CNY）
   payer_client_ip: '1.2.3.4',          // 用户 IP（可选）
   time_expire: '2026-12-31T23:59:59+08:00',  // 过期时间（可选）
@@ -241,7 +242,7 @@ SDK 自动将元转换为分，但要注意浮点数精度：
 
 ```typescript
 // 推荐：使用整数分或字符串
-const amount = 99.99;  // 会自动转换为 9999 分
+const amount_fen = 9999;  // 推荐直接使用分，避免浮点误差
 
 // 避免：复杂的浮点运算
 const badAmount = 0.1 + 0.2;  // 可能出现精度问题

--- a/docs/native-payment.md
+++ b/docs/native-payment.md
@@ -26,7 +26,7 @@ Native 支付是指商户系统生成支付二维码，用户使用微信"扫一
 const payment = await wechat.native.create({
   out_trade_no: 'order-123',           // 商户订单号（必填，6-32位）
   description: '商品描述',              // 商品描述（必填）
-  amount_fen: 9900,                    // 金额，单位分（推荐）
+  amount_cents: 9900,                    // 金额，单位分（推荐）
   // amount: 99.00,                    // 已废弃：单位元，兼容保留
   currency: 'CNY',                     // 货币类型（可选，默认 CNY）
   payer_client_ip: '1.2.3.4',          // 用户 IP（可选）
@@ -135,8 +135,8 @@ await wechat.native.close('order-123');
 const refund = await wechat.native.refund({
   out_trade_no: 'order-123',      // 原订单号
   out_refund_no: 'refund-123',    // 退款单号（必填，需唯一）
-  refund_fen: 9900,               // 退款金额（必填，单位分，推荐）
-  total_fen: 9900,                // 原订单金额（必填，单位分，推荐）
+  refund_cents: 9900,               // 退款金额（必填，单位分，推荐）
+  total_cents: 9900,                // 原订单金额（必填，单位分，推荐）
   // refund: 99.00,               // 已废弃：单位元，兼容保留
   // total: 99.00,                // 已废弃：单位元，兼容保留
   reason: '商品售后',              // 退款原因（可选，不传则不显示）
@@ -244,7 +244,7 @@ SDK 自动将元转换为分，但要注意浮点数精度：
 
 ```typescript
 // 推荐：使用整数分或字符串
-const amount_fen = 9999;  // 推荐直接使用分，避免浮点误差
+const amount_cents = 9999;  // 推荐直接使用分，避免浮点误差
 
 // 避免：复杂的浮点运算
 const badAmount = 0.1 + 0.2;  // 可能出现精度问题

--- a/docs/native-payment.md
+++ b/docs/native-payment.md
@@ -135,8 +135,10 @@ await wechat.native.close('order-123');
 const refund = await wechat.native.refund({
   out_trade_no: 'order-123',      // 原订单号
   out_refund_no: 'refund-123',    // 退款单号（必填，需唯一）
-  refund: 99.00,                  // 退款金额（必填）
-  total: 99.00,                   // 原订单金额（必填）
+  refund_fen: 9900,               // 退款金额（必填，单位分，推荐）
+  total_fen: 9900,                // 原订单金额（必填，单位分，推荐）
+  // refund: 99.00,               // 已废弃：单位元，兼容保留
+  // total: 99.00,                // 已废弃：单位元，兼容保留
   reason: '商品售后',              // 退款原因（可选，不传则不显示）
   notify_url: 'https://...',      // 退款通知地址（可选）
   funds_account: 'AVAILABLE'      // 退款资金来源（可选）

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -39,7 +39,7 @@ export class AppPayment extends BasePayment {
       goods_tag: params.goods_tag,
       support_fapiao: params.support_fapiao,
       amount: {
-        total: this.formatAmount(params.amount),
+        total: this.resolveAmountInFen(params.amount_fen, params.amount),
         currency: params.currency || 'CNY'
       },
       detail: params.detail ? {
@@ -91,7 +91,7 @@ export class AppPayment extends BasePayment {
         out_trade_no: order.out_trade_no,
         description: order.description,
         amount: {
-          total_amount: this.formatAmount(order.amount.total_amount),
+          total_amount: this.resolveAmountInFen(order.amount.total_amount_fen, order.amount.total_amount, 'sub_orders[].amount.total_amount_fen'),
           currency: order.amount.currency || 'CNY'
         },
         detail: order.detail,

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -39,7 +39,7 @@ export class AppPayment extends BasePayment {
       goods_tag: params.goods_tag,
       support_fapiao: params.support_fapiao,
       amount: {
-        total: this.resolveAmountInFen(params.amount_fen, params.amount),
+        total: this.resolveAmountInCents(params.amount_cents, params.amount),
         currency: params.currency || 'CNY'
       },
       detail: params.detail ? {
@@ -91,7 +91,7 @@ export class AppPayment extends BasePayment {
         out_trade_no: order.out_trade_no,
         description: order.description,
         amount: {
-          total_amount: this.resolveAmountInFen(order.amount.total_amount_fen, order.amount.total_amount, 'sub_orders[].amount.total_amount_fen'),
+          total_amount: this.resolveAmountInCents(order.amount.total_amount_cents, order.amount.total_amount, 'sub_orders[].amount.total_amount_cents'),
           currency: order.amount.currency || 'CNY'
         },
         detail: order.detail,

--- a/src/core/base-payment.ts
+++ b/src/core/base-payment.ts
@@ -147,8 +147,8 @@ export abstract class BasePayment {
       notify_url: params.notify_url,
       funds_account: params.funds_account,
       amount: {
-        refund: this.resolveAmountInFen(params.refund_fen, params.refund, 'refund_fen'),
-        total: this.resolveAmountInFen(params.total_fen, params.total, 'total_fen'),
+        refund: this.resolveAmountInCents(params.refund_cents, params.refund, 'refund_cents'),
+        total: this.resolveAmountInCents(params.total_cents, params.total, 'total_cents'),
         currency: params.currency || 'CNY',
         from: params.from
       },
@@ -289,12 +289,12 @@ export abstract class BasePayment {
   /**
    * 解析金额（优先使用分；兼容元）
    */
-  protected resolveAmountInFen(amount_fen: number | undefined, amount: number | undefined, fieldName = 'amount_fen'): number {
-    if (amount_fen !== undefined) {
-      if (!Number.isInteger(amount_fen) || amount_fen < 0) {
-        throw new Error(`${fieldName} must be a non-negative integer in fen`);
+  protected resolveAmountInCents(amount_cents: number | undefined, amount: number | undefined, fieldName = 'amount_cents'): number {
+    if (amount_cents !== undefined) {
+      if (!Number.isInteger(amount_cents) || amount_cents < 0) {
+        throw new Error(`${fieldName} must be a non-negative integer in cents`);
       }
-      return amount_fen;
+      return amount_cents;
     }
 
     if (amount !== undefined) {

--- a/src/core/base-payment.ts
+++ b/src/core/base-payment.ts
@@ -287,6 +287,24 @@ export abstract class BasePayment {
   }
 
   /**
+   * 解析金额（优先使用分；兼容元）
+   */
+  protected resolveAmountInFen(amount_fen: number | undefined, amount: number | undefined, fieldName = 'amount_fen'): number {
+    if (amount_fen !== undefined) {
+      if (!Number.isInteger(amount_fen) || amount_fen < 0) {
+        throw new Error(`${fieldName} must be a non-negative integer in fen`);
+      }
+      return amount_fen;
+    }
+
+    if (amount !== undefined) {
+      return this.formatAmount(amount);
+    }
+
+    throw new Error(`${fieldName} is required`);
+  }
+
+  /**
    * 递归移除对象中的 undefined 值
    */
   protected removeUndefined<T extends object>(obj: T): T {

--- a/src/core/base-payment.ts
+++ b/src/core/base-payment.ts
@@ -147,8 +147,8 @@ export abstract class BasePayment {
       notify_url: params.notify_url,
       funds_account: params.funds_account,
       amount: {
-        refund: this.formatAmount(params.refund),
-        total: this.formatAmount(params.total),
+        refund: this.resolveAmountInFen(params.refund_fen, params.refund, 'refund_fen'),
+        total: this.resolveAmountInFen(params.total_fen, params.total, 'total_fen'),
         currency: params.currency || 'CNY',
         from: params.from
       },

--- a/src/h5/h5.ts
+++ b/src/h5/h5.ts
@@ -48,7 +48,7 @@ export class H5Payment extends BasePayment {
       goods_tag: params.goods_tag,
       support_fapiao: params.support_fapiao,
       amount: {
-        total: this.formatAmount(params.amount),
+        total: this.resolveAmountInFen(params.amount_fen, params.amount),
         currency: params.currency || 'CNY'
       },
       detail: params.detail ? {
@@ -123,7 +123,7 @@ export class H5Payment extends BasePayment {
         out_trade_no: order.out_trade_no,
         description: order.description,
         amount: {
-          total_amount: this.formatAmount(order.amount.total_amount),
+          total_amount: this.resolveAmountInFen(order.amount.total_amount_fen, order.amount.total_amount, 'sub_orders[].amount.total_amount_fen'),
           currency: order.amount.currency || 'CNY'
         },
         detail: order.detail,

--- a/src/h5/h5.ts
+++ b/src/h5/h5.ts
@@ -48,7 +48,7 @@ export class H5Payment extends BasePayment {
       goods_tag: params.goods_tag,
       support_fapiao: params.support_fapiao,
       amount: {
-        total: this.resolveAmountInFen(params.amount_fen, params.amount),
+        total: this.resolveAmountInCents(params.amount_cents, params.amount),
         currency: params.currency || 'CNY'
       },
       detail: params.detail ? {
@@ -123,7 +123,7 @@ export class H5Payment extends BasePayment {
         out_trade_no: order.out_trade_no,
         description: order.description,
         amount: {
-          total_amount: this.resolveAmountInFen(order.amount.total_amount_fen, order.amount.total_amount, 'sub_orders[].amount.total_amount_fen'),
+          total_amount: this.resolveAmountInCents(order.amount.total_amount_cents, order.amount.total_amount, 'sub_orders[].amount.total_amount_cents'),
           currency: order.amount.currency || 'CNY'
         },
         detail: order.detail,

--- a/src/jsapi/jsapi.ts
+++ b/src/jsapi/jsapi.ts
@@ -46,7 +46,7 @@ export class JSAPIPayment extends BasePayment {
       goods_tag: params.goods_tag,
       support_fapiao: params.support_fapiao,
       amount: {
-        total: this.formatAmount(params.amount),
+        total: this.resolveAmountInFen(params.amount_fen, params.amount),
         currency: params.currency || 'CNY'
       },
       payer: {
@@ -102,7 +102,7 @@ export class JSAPIPayment extends BasePayment {
         out_trade_no: order.out_trade_no,
         description: order.description,
         amount: {
-          total_amount: this.formatAmount(order.amount.total_amount),
+          total_amount: this.resolveAmountInFen(order.amount.total_amount_fen, order.amount.total_amount, 'sub_orders[].amount.total_amount_fen'),
           currency: order.amount.currency || 'CNY'
         },
         detail: order.detail,
@@ -150,7 +150,7 @@ export class JSAPIPayment extends BasePayment {
         out_trade_no: order.out_trade_no,
         description: order.description,
         amount: {
-          total_amount: this.formatAmount(order.amount.total_amount),
+          total_amount: this.resolveAmountInFen(order.amount.total_amount_fen, order.amount.total_amount, 'sub_orders[].amount.total_amount_fen'),
           currency: order.amount.currency || 'CNY'
         },
         detail: order.detail,

--- a/src/jsapi/jsapi.ts
+++ b/src/jsapi/jsapi.ts
@@ -46,7 +46,7 @@ export class JSAPIPayment extends BasePayment {
       goods_tag: params.goods_tag,
       support_fapiao: params.support_fapiao,
       amount: {
-        total: this.resolveAmountInFen(params.amount_fen, params.amount),
+        total: this.resolveAmountInCents(params.amount_cents, params.amount),
         currency: params.currency || 'CNY'
       },
       payer: {
@@ -102,7 +102,7 @@ export class JSAPIPayment extends BasePayment {
         out_trade_no: order.out_trade_no,
         description: order.description,
         amount: {
-          total_amount: this.resolveAmountInFen(order.amount.total_amount_fen, order.amount.total_amount, 'sub_orders[].amount.total_amount_fen'),
+          total_amount: this.resolveAmountInCents(order.amount.total_amount_cents, order.amount.total_amount, 'sub_orders[].amount.total_amount_cents'),
           currency: order.amount.currency || 'CNY'
         },
         detail: order.detail,
@@ -150,7 +150,7 @@ export class JSAPIPayment extends BasePayment {
         out_trade_no: order.out_trade_no,
         description: order.description,
         amount: {
-          total_amount: this.resolveAmountInFen(order.amount.total_amount_fen, order.amount.total_amount, 'sub_orders[].amount.total_amount_fen'),
+          total_amount: this.resolveAmountInCents(order.amount.total_amount_cents, order.amount.total_amount, 'sub_orders[].amount.total_amount_cents'),
           currency: order.amount.currency || 'CNY'
         },
         detail: order.detail,

--- a/src/native/native.ts
+++ b/src/native/native.ts
@@ -38,7 +38,7 @@ export class NativePayment extends BasePayment {
       goods_tag: params.goods_tag,
       support_fapiao: params.support_fapiao,
       amount: {
-        total: this.formatAmount(params.amount),
+        total: this.resolveAmountInFen(params.amount_fen, params.amount),
         currency: params.currency || 'CNY'
       },
       detail: params.detail ? {
@@ -88,8 +88,8 @@ export class NativePayment extends BasePayment {
         attach: order.attach,
         out_trade_no: order.out_trade_no,
         description: order.description,
-      amount: {
-          total_amount: this.formatAmount(order.amount.total_amount),
+        amount: {
+          total_amount: this.resolveAmountInFen(order.amount.total_amount_fen, order.amount.total_amount, 'sub_orders[].amount.total_amount_fen'),
           currency: order.amount.currency || 'CNY'
         },
         detail: order.detail,

--- a/src/native/native.ts
+++ b/src/native/native.ts
@@ -38,7 +38,7 @@ export class NativePayment extends BasePayment {
       goods_tag: params.goods_tag,
       support_fapiao: params.support_fapiao,
       amount: {
-        total: this.resolveAmountInFen(params.amount_fen, params.amount),
+        total: this.resolveAmountInCents(params.amount_cents, params.amount),
         currency: params.currency || 'CNY'
       },
       detail: params.detail ? {
@@ -89,7 +89,7 @@ export class NativePayment extends BasePayment {
         out_trade_no: order.out_trade_no,
         description: order.description,
         amount: {
-          total_amount: this.resolveAmountInFen(order.amount.total_amount_fen, order.amount.total_amount, 'sub_orders[].amount.total_amount_fen'),
+          total_amount: this.resolveAmountInCents(order.amount.total_amount_cents, order.amount.total_amount, 'sub_orders[].amount.total_amount_cents'),
           currency: order.amount.currency || 'CNY'
         },
         detail: order.detail,

--- a/src/types/payment.ts
+++ b/src/types/payment.ts
@@ -59,12 +59,13 @@ export interface SettleInfo {
 
 // ==================== Native 支付 ====================
 
-export interface CreateNativePaymentParams {
+type NativeAmountInput =
+  | { amount_fen: number; /** @deprecated 请改用 amount_fen（单位：分） */ amount?: number }
+  | { amount_fen?: number; /** @deprecated 请改用 amount_fen（单位：分） */ amount: number };
+
+export type CreateNativePaymentParams = {
   out_trade_no: string;
   description: string;
-  amount_fen?: number;
-  /** @deprecated 请改用 amount_fen（单位：分） */
-  amount?: number;
   currency?: string;
   payer_client_ip?: string;
   time_expire?: string;
@@ -74,7 +75,7 @@ export interface CreateNativePaymentParams {
   detail?: OrderDetail;
   scene_info?: SceneInfo;
   settle_info?: SettleInfo;
-}
+} & NativeAmountInput;
 
 export interface CreateNativePaymentResult {
   code_url: string;
@@ -83,12 +84,13 @@ export interface CreateNativePaymentResult {
 
 // ==================== APP 支付 ====================
 
-export interface CreateAppPaymentParams {
+type AppAmountInput =
+  | { amount_fen: number; /** @deprecated 请改用 amount_fen（单位：分） */ amount?: number }
+  | { amount_fen?: number; /** @deprecated 请改用 amount_fen（单位：分） */ amount: number };
+
+export type CreateAppPaymentParams = {
   out_trade_no: string;
   description: string;
-  amount_fen?: number;
-  /** @deprecated 请改用 amount_fen（单位：分） */
-  amount?: number;
   currency?: string;
   payer_client_ip?: string;
   time_expire?: string;
@@ -98,7 +100,7 @@ export interface CreateAppPaymentParams {
   detail?: OrderDetail;
   scene_info?: SceneInfo;
   settle_info?: SettleInfo;
-}
+} & AppAmountInput;
 
 export interface CreateAppPaymentResult {
   prepay_id: string;
@@ -107,12 +109,13 @@ export interface CreateAppPaymentResult {
 
 // ==================== JSAPI / 小程序支付 ====================
 
-export interface CreateJSAPIPaymentParams {
+type JSAPIAmountInput =
+  | { amount_fen: number; /** @deprecated 请改用 amount_fen（单位：分） */ amount?: number }
+  | { amount_fen?: number; /** @deprecated 请改用 amount_fen（单位：分） */ amount: number };
+
+export type CreateJSAPIPaymentParams = {
   out_trade_no: string;
   description: string;
-  amount_fen?: number;
-  /** @deprecated 请改用 amount_fen（单位：分） */
-  amount?: number;
   currency?: string;
   openid: string;  // 必填：用户在商户appid下的唯一标识
   payer_client_ip?: string;
@@ -123,7 +126,7 @@ export interface CreateJSAPIPaymentParams {
   detail?: OrderDetail;
   scene_info?: SceneInfo;
   settle_info?: SettleInfo;
-}
+} & JSAPIAmountInput;
 
 export interface CreateJSAPIPaymentResult {
   prepay_id: string;
@@ -147,12 +150,13 @@ export interface H5SceneInfo {
   h5_info: H5Info;  // H5支付必填
 }
 
-export interface CreateH5PaymentParams {
+type H5AmountInput =
+  | { amount_fen: number; /** @deprecated 请改用 amount_fen（单位：分） */ amount?: number }
+  | { amount_fen?: number; /** @deprecated 请改用 amount_fen（单位：分） */ amount: number };
+
+export type CreateH5PaymentParams = {
   out_trade_no: string;
   description: string;
-  amount_fen?: number;
-  /** @deprecated 请改用 amount_fen（单位：分） */
-  amount?: number;
   currency?: string;
   payer_client_ip?: string;  // 便捷设置，会合并到 scene_info.payer_client_ip
   time_expire?: string;
@@ -163,7 +167,7 @@ export interface CreateH5PaymentParams {
   scene_info?: H5SceneInfo;  // H5支付场景信息（包含 h5_info）
   settle_info?: SettleInfo;
   h5_info?: H5Info;  // 便捷设置，会合并到 scene_info.h5_info
-}
+} & H5AmountInput;
 
 export interface CreateH5PaymentResult {
   h5_url: string;
@@ -172,12 +176,19 @@ export interface CreateH5PaymentResult {
 
 // ==================== 合单支付 ====================
 
-export interface CombineSubOrderAmount {
-  total_amount_fen?: number; // 单位：分（推荐）
-  /** @deprecated 请改用 total_amount_fen（单位：分） */
-  total_amount?: number; // 单位：元（SDK 会自动转换为分）
-  currency?: string;
-}
+export type CombineSubOrderAmount =
+  | {
+      total_amount_fen: number; // 单位：分（推荐）
+      /** @deprecated 请改用 total_amount_fen（单位：分） */
+      total_amount?: number; // 单位：元（SDK 会自动转换为分）
+      currency?: string;
+    }
+  | {
+      total_amount_fen?: number; // 单位：分（推荐）
+      /** @deprecated 请改用 total_amount_fen（单位：分） */
+      total_amount: number; // 单位：元（SDK 会自动转换为分）
+      currency?: string;
+    };
 
 export interface CombineSubOrder {
   mchid: string;

--- a/src/types/payment.ts
+++ b/src/types/payment.ts
@@ -327,15 +327,31 @@ export interface CloseCombineOrderParams {
 
 // ==================== 退款 ====================
 
-export interface RefundParams {
+type RefundAmountInput =
+  | {
+      refund_fen: number;
+      total_fen: number;
+      /** @deprecated 请改用 refund_fen（单位：分） */
+      refund?: number;
+      /** @deprecated 请改用 total_fen（单位：分） */
+      total?: number;
+    }
+  | {
+      refund_fen?: number;
+      total_fen?: number;
+      /** @deprecated 请改用 refund_fen（单位：分） */
+      refund: number;
+      /** @deprecated 请改用 total_fen（单位：分） */
+      total: number;
+    };
+
+export type RefundParams = {
   transaction_id?: string;
   out_trade_no?: string;
   out_refund_no: string;
   reason?: string;
   notify_url?: string;
   funds_account?: 'AVAILABLE' | 'UNSETTLED';
-  refund: number;
-  total: number;
   currency?: string;
   from?: Array<{ account: 'AVAILABLE' | 'UNAVAILABLE'; amount: number }>;
   goods_detail?: Array<{
@@ -346,7 +362,7 @@ export interface RefundParams {
     refund_amount: number;
     refund_quantity: number;
   }>;
-}
+} & RefundAmountInput;
 
 export interface RefundResult {
   refund_id: string;

--- a/src/types/payment.ts
+++ b/src/types/payment.ts
@@ -62,7 +62,9 @@ export interface SettleInfo {
 export interface CreateNativePaymentParams {
   out_trade_no: string;
   description: string;
-  amount: number;
+  amount_fen?: number;
+  /** @deprecated 请改用 amount_fen（单位：分） */
+  amount?: number;
   currency?: string;
   payer_client_ip?: string;
   time_expire?: string;
@@ -84,7 +86,9 @@ export interface CreateNativePaymentResult {
 export interface CreateAppPaymentParams {
   out_trade_no: string;
   description: string;
-  amount: number;
+  amount_fen?: number;
+  /** @deprecated 请改用 amount_fen（单位：分） */
+  amount?: number;
   currency?: string;
   payer_client_ip?: string;
   time_expire?: string;
@@ -106,7 +110,9 @@ export interface CreateAppPaymentResult {
 export interface CreateJSAPIPaymentParams {
   out_trade_no: string;
   description: string;
-  amount: number;
+  amount_fen?: number;
+  /** @deprecated 请改用 amount_fen（单位：分） */
+  amount?: number;
   currency?: string;
   openid: string;  // 必填：用户在商户appid下的唯一标识
   payer_client_ip?: string;
@@ -144,7 +150,9 @@ export interface H5SceneInfo {
 export interface CreateH5PaymentParams {
   out_trade_no: string;
   description: string;
-  amount: number;
+  amount_fen?: number;
+  /** @deprecated 请改用 amount_fen（单位：分） */
+  amount?: number;
   currency?: string;
   payer_client_ip?: string;  // 便捷设置，会合并到 scene_info.payer_client_ip
   time_expire?: string;
@@ -165,7 +173,9 @@ export interface CreateH5PaymentResult {
 // ==================== 合单支付 ====================
 
 export interface CombineSubOrderAmount {
-  total_amount: number; // 单位：元（SDK 会自动转换为分）
+  total_amount_fen?: number; // 单位：分（推荐）
+  /** @deprecated 请改用 total_amount_fen（单位：分） */
+  total_amount?: number; // 单位：元（SDK 会自动转换为分）
   currency?: string;
 }
 

--- a/src/types/payment.ts
+++ b/src/types/payment.ts
@@ -60,8 +60,8 @@ export interface SettleInfo {
 // ==================== Native 支付 ====================
 
 type NativeAmountInput =
-  | { amount_fen: number; /** @deprecated 请改用 amount_fen（单位：分） */ amount?: number }
-  | { amount_fen?: number; /** @deprecated 请改用 amount_fen（单位：分） */ amount: number };
+  | { amount_cents: number; /** @deprecated 请改用 amount_cents（单位：分） */ amount?: number }
+  | { amount_cents?: number; /** @deprecated 请改用 amount_cents（单位：分） */ amount: number };
 
 export type CreateNativePaymentParams = {
   out_trade_no: string;
@@ -85,8 +85,8 @@ export interface CreateNativePaymentResult {
 // ==================== APP 支付 ====================
 
 type AppAmountInput =
-  | { amount_fen: number; /** @deprecated 请改用 amount_fen（单位：分） */ amount?: number }
-  | { amount_fen?: number; /** @deprecated 请改用 amount_fen（单位：分） */ amount: number };
+  | { amount_cents: number; /** @deprecated 请改用 amount_cents（单位：分） */ amount?: number }
+  | { amount_cents?: number; /** @deprecated 请改用 amount_cents（单位：分） */ amount: number };
 
 export type CreateAppPaymentParams = {
   out_trade_no: string;
@@ -110,8 +110,8 @@ export interface CreateAppPaymentResult {
 // ==================== JSAPI / 小程序支付 ====================
 
 type JSAPIAmountInput =
-  | { amount_fen: number; /** @deprecated 请改用 amount_fen（单位：分） */ amount?: number }
-  | { amount_fen?: number; /** @deprecated 请改用 amount_fen（单位：分） */ amount: number };
+  | { amount_cents: number; /** @deprecated 请改用 amount_cents（单位：分） */ amount?: number }
+  | { amount_cents?: number; /** @deprecated 请改用 amount_cents（单位：分） */ amount: number };
 
 export type CreateJSAPIPaymentParams = {
   out_trade_no: string;
@@ -151,8 +151,8 @@ export interface H5SceneInfo {
 }
 
 type H5AmountInput =
-  | { amount_fen: number; /** @deprecated 请改用 amount_fen（单位：分） */ amount?: number }
-  | { amount_fen?: number; /** @deprecated 请改用 amount_fen（单位：分） */ amount: number };
+  | { amount_cents: number; /** @deprecated 请改用 amount_cents（单位：分） */ amount?: number }
+  | { amount_cents?: number; /** @deprecated 请改用 amount_cents（单位：分） */ amount: number };
 
 export type CreateH5PaymentParams = {
   out_trade_no: string;
@@ -178,14 +178,14 @@ export interface CreateH5PaymentResult {
 
 export type CombineSubOrderAmount =
   | {
-      total_amount_fen: number; // 单位：分（推荐）
-      /** @deprecated 请改用 total_amount_fen（单位：分） */
+      total_amount_cents: number; // 单位：分（推荐）
+      /** @deprecated 请改用 total_amount_cents（单位：分） */
       total_amount?: number; // 单位：元（SDK 会自动转换为分）
       currency?: string;
     }
   | {
-      total_amount_fen?: number; // 单位：分（推荐）
-      /** @deprecated 请改用 total_amount_fen（单位：分） */
+      total_amount_cents?: number; // 单位：分（推荐）
+      /** @deprecated 请改用 total_amount_cents（单位：分） */
       total_amount: number; // 单位：元（SDK 会自动转换为分）
       currency?: string;
     };
@@ -329,19 +329,19 @@ export interface CloseCombineOrderParams {
 
 type RefundAmountInput =
   | {
-      refund_fen: number;
-      total_fen: number;
-      /** @deprecated 请改用 refund_fen（单位：分） */
+      refund_cents: number;
+      total_cents: number;
+      /** @deprecated 请改用 refund_cents（单位：分） */
       refund?: number;
-      /** @deprecated 请改用 total_fen（单位：分） */
+      /** @deprecated 请改用 total_cents（单位：分） */
       total?: number;
     }
   | {
-      refund_fen?: number;
-      total_fen?: number;
-      /** @deprecated 请改用 refund_fen（单位：分） */
+      refund_cents?: number;
+      total_cents?: number;
+      /** @deprecated 请改用 refund_cents（单位：分） */
       refund: number;
-      /** @deprecated 请改用 total_fen（单位：分） */
+      /** @deprecated 请改用 total_cents（单位：分） */
       total: number;
     };
 

--- a/tests/unit/app/app.test.ts
+++ b/tests/unit/app/app.test.ts
@@ -22,7 +22,7 @@ describe('AppPayment', () => {
     const result = await appPayment.create({
       out_trade_no: 'order123',
       description: '测试支付',
-      amount_fen: 9900,
+      amount_cents: 9900,
       payer_client_ip: '1.2.3.4'
     });
 
@@ -53,7 +53,7 @@ describe('AppPayment', () => {
           description: '子单商品',
           attach: 'attach_data',
           amount: {
-            total_amount_fen: 1001
+            total_amount_cents: 1001
           }
         }
       ]

--- a/tests/unit/app/app.test.ts
+++ b/tests/unit/app/app.test.ts
@@ -22,7 +22,7 @@ describe('AppPayment', () => {
     const result = await appPayment.create({
       out_trade_no: 'order123',
       description: '测试支付',
-      amount: 99.00,
+      amount_fen: 9900,
       payer_client_ip: '1.2.3.4'
     });
 
@@ -53,7 +53,7 @@ describe('AppPayment', () => {
           description: '子单商品',
           attach: 'attach_data',
           amount: {
-            total_amount: 10.01
+            total_amount_fen: 1001
           }
         }
       ]

--- a/tests/unit/h5/h5.test.ts
+++ b/tests/unit/h5/h5.test.ts
@@ -30,7 +30,7 @@ describe('H5Payment', () => {
     const result = await h5Payment.create({
       out_trade_no: 'order123',
       description: '测试支付',
-      amount: 99.00,
+      amount_fen: 9900,
       payer_client_ip: '1.2.3.4',
       h5_info: {
         type: 'Wap',
@@ -76,7 +76,7 @@ describe('H5Payment', () => {
           description: '子单商品',
           attach: 'attach_data',
           amount: {
-            total_amount: 10.01
+            total_amount_fen: 1001
           }
         }
       ]

--- a/tests/unit/h5/h5.test.ts
+++ b/tests/unit/h5/h5.test.ts
@@ -30,7 +30,7 @@ describe('H5Payment', () => {
     const result = await h5Payment.create({
       out_trade_no: 'order123',
       description: '测试支付',
-      amount_fen: 9900,
+      amount_cents: 9900,
       payer_client_ip: '1.2.3.4',
       h5_info: {
         type: 'Wap',
@@ -76,7 +76,7 @@ describe('H5Payment', () => {
           description: '子单商品',
           attach: 'attach_data',
           amount: {
-            total_amount_fen: 1001
+            total_amount_cents: 1001
           }
         }
       ]

--- a/tests/unit/jsapi/jsapi.test.ts
+++ b/tests/unit/jsapi/jsapi.test.ts
@@ -30,7 +30,7 @@ describe('JSAPIPayment', () => {
     const result = await jsapiPayment.create({
       out_trade_no: 'order123',
       description: '测试支付',
-      amount_fen: 9900,
+      amount_cents: 9900,
       openid: 'openid123',
       payer_client_ip: '1.2.3.4'
     });
@@ -63,7 +63,7 @@ describe('JSAPIPayment', () => {
           description: '子单商品',
           attach: 'attach_data',
           amount: {
-            total_amount_fen: 1001
+            total_amount_cents: 1001
           }
         }
       ]
@@ -101,7 +101,7 @@ describe('JSAPIPayment', () => {
           description: '子单商品',
           attach: 'attach_data',
           amount: {
-            total_amount_fen: 123
+            total_amount_cents: 123
           }
         }
       ]

--- a/tests/unit/jsapi/jsapi.test.ts
+++ b/tests/unit/jsapi/jsapi.test.ts
@@ -30,7 +30,7 @@ describe('JSAPIPayment', () => {
     const result = await jsapiPayment.create({
       out_trade_no: 'order123',
       description: '测试支付',
-      amount: 99.00,
+      amount_fen: 9900,
       openid: 'openid123',
       payer_client_ip: '1.2.3.4'
     });
@@ -63,7 +63,7 @@ describe('JSAPIPayment', () => {
           description: '子单商品',
           attach: 'attach_data',
           amount: {
-            total_amount: 10.01
+            total_amount_fen: 1001
           }
         }
       ]
@@ -101,7 +101,7 @@ describe('JSAPIPayment', () => {
           description: '子单商品',
           attach: 'attach_data',
           amount: {
-            total_amount: 1.23
+            total_amount_fen: 123
           }
         }
       ]

--- a/tests/unit/native/native.test.ts
+++ b/tests/unit/native/native.test.ts
@@ -27,7 +27,7 @@ describe('NativePayment', () => {
       const result = await nativePayment.create({
         out_trade_no: 'order123',
         description: '测试支付',
-        amount: 99.00,
+        amount_fen: 9900,
         payer_client_ip: '1.2.3.4'
       });
 
@@ -87,6 +87,36 @@ describe('NativePayment', () => {
           time_expire: '2024-12-31T23:59:59+08:00'
         })
       );
+    });
+
+
+    it('应优先使用 amount_fen（分）并跳过元转换', async () => {
+      mockClient.request.mockResolvedValue({ code_url: 'weixin://test' });
+
+      await nativePayment.create({
+        out_trade_no: 'order123',
+        description: '测试',
+        amount_fen: 1001,
+        amount: 10.01
+      });
+
+      expect(mockClient.request).toHaveBeenCalledWith(
+        'POST',
+        '/v3/pay/transactions/native',
+        expect.objectContaining({
+          amount: expect.objectContaining({
+            total: 1001
+          })
+        })
+      );
+    });
+
+    it('amount_fen 非整数时应抛出错误', async () => {
+      await expect(nativePayment.create({
+        out_trade_no: 'order123',
+        description: '测试',
+        amount_fen: 10.5
+      } as any)).rejects.toThrow('amount_fen must be a non-negative integer in fen');
     });
 
     it('应正确处理 detail 和 scene_info', async () => {

--- a/tests/unit/native/native.test.ts
+++ b/tests/unit/native/native.test.ts
@@ -27,7 +27,7 @@ describe('NativePayment', () => {
       const result = await nativePayment.create({
         out_trade_no: 'order123',
         description: '测试支付',
-        amount_fen: 9900,
+        amount_cents: 9900,
         payer_client_ip: '1.2.3.4'
       });
 
@@ -90,13 +90,13 @@ describe('NativePayment', () => {
     });
 
 
-    it('应优先使用 amount_fen（分）并跳过元转换', async () => {
+    it('应优先使用 amount_cents（分）并跳过元转换', async () => {
       mockClient.request.mockResolvedValue({ code_url: 'weixin://test' });
 
       await nativePayment.create({
         out_trade_no: 'order123',
         description: '测试',
-        amount_fen: 1001,
+        amount_cents: 1001,
         amount: 10.01
       });
 
@@ -111,12 +111,12 @@ describe('NativePayment', () => {
       );
     });
 
-    it('amount_fen 非整数时应抛出错误', async () => {
+    it('amount_cents 非整数时应抛出错误', async () => {
       await expect(nativePayment.create({
         out_trade_no: 'order123',
         description: '测试',
-        amount_fen: 10.5
-      } as any)).rejects.toThrow('amount_fen must be a non-negative integer in fen');
+        amount_cents: 10.5
+      } as any)).rejects.toThrow('amount_cents must be a non-negative integer in cents');
     });
 
     it('应正确处理 detail 和 scene_info', async () => {
@@ -246,8 +246,8 @@ describe('NativePayment', () => {
       const result = await nativePayment.refund({
         out_trade_no: 'order123',
         out_refund_no: 'refund_order123',
-        refund_fen: 100,
-        total_fen: 100
+        refund_cents: 100,
+        total_cents: 100
       });
 
       expect(result.refund_id).toBe('refund123');
@@ -265,13 +265,13 @@ describe('NativePayment', () => {
     });
 
 
-    it('refund_fen 非整数时应抛出错误', async () => {
+    it('refund_cents 非整数时应抛出错误', async () => {
       await expect(nativePayment.refund({
         out_trade_no: 'order123',
         out_refund_no: 'refund_order123',
-        refund_fen: 10.5,
-        total_fen: 100
-      } as any)).rejects.toThrow('refund_fen must be a non-negative integer in fen');
+        refund_cents: 10.5,
+        total_cents: 100
+      } as any)).rejects.toThrow('refund_cents must be a non-negative integer in cents');
     });
 
     it('应正确处理退款原因', async () => {

--- a/tests/unit/native/native.test.ts
+++ b/tests/unit/native/native.test.ts
@@ -246,8 +246,8 @@ describe('NativePayment', () => {
       const result = await nativePayment.refund({
         out_trade_no: 'order123',
         out_refund_no: 'refund_order123',
-        refund: 1.00,
-        total: 1.00
+        refund_fen: 100,
+        total_fen: 100
       });
 
       expect(result.refund_id).toBe('refund123');
@@ -262,6 +262,16 @@ describe('NativePayment', () => {
           })
         })
       );
+    });
+
+
+    it('refund_fen 非整数时应抛出错误', async () => {
+      await expect(nativePayment.refund({
+        out_trade_no: 'order123',
+        out_refund_no: 'refund_order123',
+        refund_fen: 10.5,
+        total_fen: 100
+      } as any)).rejects.toThrow('refund_fen must be a non-negative integer in fen');
     });
 
     it('应正确处理退款原因', async () => {


### PR DESCRIPTION
### Motivation

- Avoid floating-point precision issues by supporting amounts in integer fen (`amount_fen`) and gradually deprecating the yuan-based `amount` field. 
- Provide a clear migration path and validation to ensure callers send non-negative integer cents when required. 

### Description

- Added `resolveAmountInFen` to `BasePayment` to prefer `amount_fen` and fall back to `amount` (converted via `formatAmount`), and to validate that fen values are non-negative integers. 
- Replaced usages of `formatAmount(params.amount)` with `resolveAmountInFen(params.amount_fen, params.amount)` across `native`, `h5`, `jsapi`, and `app` payment implementations (including combine order handling). 
- Updated TypeScript types in `src/types/payment.ts` to add optional `amount_fen` / `total_amount_fen` fields and mark `amount` / `total_amount` as deprecated. 
- Updated documentation and `README.md` to recommend `amount_fen`, show examples, and document changed API reference and native/H5 guides. 
- Updated unit tests to use `amount_fen` and added tests for precedence and validation (ensure `amount_fen` is used when present and error on non-integer fen). 

### Testing

- Ran unit tests with `vitest` (updated tests under `tests/unit/*`) and all modified/added tests passed. 
- Added assertions in tests to verify request payloads include integer fen totals and that invalid `amount_fen` values throw the expected error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b006ebf5b88321b1562ba814ba4a51)