### PR TITLE
feat: add option to skip platform certificate fetch during SDK init

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ const wechat = new WeChatPay({
     // 可选但推荐：微信支付公钥验签（无有效期限制）
     paymentPublicKey: process.env.WECHAT_PAY_PAYMENT_PUBLIC_KEY,
     publicKeyId: process.env.WECHAT_PAY_PUBLIC_KEY_ID,
-    // 新商户仅使用微信支付公钥时可开启（默认 false）
-    skipFetchPlatformCertificates: true,
+    // 如果配置了 paymentPublicKey + publicKeyId，会默认跳过拉取平台证书
+    // 仅灰度兼容场景才需要强制拉取
+    forceFetchPlatformCertificates: false,
     notifyUrl: 'https://your-domain.com/webhook/wechat'
   }
 });
@@ -94,6 +95,12 @@ MIIEvgIBADAN...
 # 格式如：PUB_KEY_ID_0000000000000024101100397200000006
 WECHAT_PAY_PUBLIC_KEY_ID="PUB_KEY_ID_xxxx"
 ```
+
+## 初始化证书拉取行为
+
+- 默认情况下，SDK 会在初始化时拉取平台证书。
+- 当同时配置 `paymentPublicKey` 和 `publicKeyId` 时，SDK 会默认跳过拉取平台证书（适合新商户仅公钥模式）。
+- 如需灰度兼容（同时可能收到平台证书序列号签名），可设置 `forceFetchPlatformCertificates: true` 强制拉取。
 
 ## 支付方式
 
@@ -160,7 +167,13 @@ const payment = await wechat.h5.create({
 - [安全指南](docs/security.md)
 - [错误码](docs/error-codes.md)
 
-### 支付方式
+### 初始化证书拉取行为
+
+- 默认情况下，SDK 会在初始化时拉取平台证书。
+- 当同时配置 `paymentPublicKey` 和 `publicKeyId` 时，SDK 会默认跳过拉取平台证书（适合新商户仅公钥模式）。
+- 如需灰度兼容（同时可能收到平台证书序列号签名），可设置 `forceFetchPlatformCertificates: true` 强制拉取。
+
+## 支付方式
 - [Native 支付（扫码支付）](docs/native-payment.md)
 - [APP 支付](docs/app-payment.md)
 - [JSAPI 支付](docs/jsapi-payment.md)

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ const wechat = new WeChatPay({
     // 可选但推荐：微信支付公钥验签（无有效期限制）
     paymentPublicKey: process.env.WECHAT_PAY_PAYMENT_PUBLIC_KEY,
     publicKeyId: process.env.WECHAT_PAY_PUBLIC_KEY_ID,
+    // 新商户仅使用微信支付公钥时可开启（默认 false）
+    skipFetchPlatformCertificates: true,
     notifyUrl: 'https://your-domain.com/webhook/wechat'
   }
 });

--- a/README.md
+++ b/README.md
@@ -167,12 +167,6 @@ const payment = await wechat.h5.create({
 - [安全指南](docs/security.md)
 - [错误码](docs/error-codes.md)
 
-### 初始化证书拉取行为
-
-- 默认情况下，SDK 会在初始化时拉取平台证书。
-- 当同时配置 `paymentPublicKey` 和 `publicKeyId` 时，SDK 会默认跳过拉取平台证书（适合新商户仅公钥模式）。
-- 如需灰度兼容（同时可能收到平台证书序列号签名），可设置 `forceFetchPlatformCertificates: true` 强制拉取。
-
 ## 支付方式
 - [Native 支付（扫码支付）](docs/native-payment.md)
 - [APP 支付](docs/app-payment.md)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -23,6 +23,7 @@ interface WeChatPayConfig {
   publicKey: Buffer | string;   // 商户证书 PEM（必填）
   paymentPublicKey?: Buffer | string;  // 微信支付公钥（可选）
   publicKeyId?: string;         // 公钥 ID（使用 paymentPublicKey 时必填）
+  skipFetchPlatformCertificates?: boolean; // 是否跳过初始化时获取平台证书（默认 false）
   notifyUrl?: string;           // 回调通知地址
   baseUrl?: string;             // API 基础 URL（默认生产环境）
   debug?: boolean;              // 调试模式

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -23,7 +23,6 @@ interface WeChatPayConfig {
   publicKey: Buffer | string;   // 商户证书 PEM（必填）
   paymentPublicKey?: Buffer | string;  // 微信支付公钥（可选）
   publicKeyId?: string;         // 公钥 ID（使用 paymentPublicKey 时必填）
-  skipFetchPlatformCertificates?: boolean; // 手动跳过初始化时获取平台证书（可选）
   forceFetchPlatformCertificates?: boolean; // 强制初始化时获取平台证书（默认 false）
   notifyUrl?: string;           // 回调通知地址
   baseUrl?: string;             // API 基础 URL（默认生产环境）

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -23,12 +23,18 @@ interface WeChatPayConfig {
   publicKey: Buffer | string;   // 商户证书 PEM（必填）
   paymentPublicKey?: Buffer | string;  // 微信支付公钥（可选）
   publicKeyId?: string;         // 公钥 ID（使用 paymentPublicKey 时必填）
-  skipFetchPlatformCertificates?: boolean; // 是否跳过初始化时获取平台证书（默认 false）
+  skipFetchPlatformCertificates?: boolean; // 手动跳过初始化时获取平台证书（可选）
+  forceFetchPlatformCertificates?: boolean; // 强制初始化时获取平台证书（默认 false）
   notifyUrl?: string;           // 回调通知地址
   baseUrl?: string;             // API 基础 URL（默认生产环境）
   debug?: boolean;              // 调试模式
 }
 ```
+
+> 初始化证书策略：
+> - 默认会拉取平台证书。
+> - 若同时提供 `paymentPublicKey` + `publicKeyId`，默认跳过拉取。
+> - 设置 `forceFetchPlatformCertificates: true` 可强制拉取。
 
 ### 属性
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -98,11 +98,17 @@ const wechat = new WeChatPay({
     // 可选但推荐：微信支付公钥验签（无有效期限制）
     paymentPublicKey: process.env.WECHAT_PAY_PAYMENT_PUBLIC_KEY,
     publicKeyId: process.env.WECHAT_PAY_PUBLIC_KEY_ID,
-    // 新商户如未开通平台证书接口，可手动跳过初始化拉取
-    skipFetchPlatformCertificates: true,
+    // 配置了 paymentPublicKey + publicKeyId 后会默认跳过平台证书拉取
+    // 灰度兼容场景可强制拉取
+    forceFetchPlatformCertificates: false,
   }
 });
 ```
+
+
+> 💡 提示：当你同时配置 `paymentPublicKey` 和 `publicKeyId` 时，SDK 默认不请求 `/v3/certificates`。
+>
+> 只有在灰度阶段需要同时兼容“平台证书签名 + 公钥签名”时，才建议设置 `forceFetchPlatformCertificates: true`。
 
 ## 第五步：创建你的第一笔支付
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -98,6 +98,8 @@ const wechat = new WeChatPay({
     // 可选但推荐：微信支付公钥验签（无有效期限制）
     paymentPublicKey: process.env.WECHAT_PAY_PAYMENT_PUBLIC_KEY,
     publicKeyId: process.env.WECHAT_PAY_PUBLIC_KEY_ID,
+    // 新商户如未开通平台证书接口，可手动跳过初始化拉取
+    skipFetchPlatformCertificates: true,
   }
 });
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ export class WeChatPay {
   public readonly webhook: Webhook;
   private readonly httpClient: HttpClient;
   private readonly certManager: CertificateManager;
+  private readonly initPromise: Promise<void>;
 
   constructor(options: any) {
     const config = loadConfig(options);
@@ -43,7 +44,7 @@ export class WeChatPay {
     this.h5 = new H5Payment(httpClient, this);
     this.webhook = new Webhook(verifier, cryptoUtils, this);
 
-    this.initializeCertificates(certManager, httpClient, config);
+    this.initPromise = this.initializeCertificates(certManager, httpClient, config);
   }
 
   /**
@@ -77,11 +78,7 @@ export class WeChatPay {
 
   public static async initialize(options: any): Promise<WeChatPay> {
     const instance = new WeChatPay(options);
-    await instance.initializeCertificates(
-      instance.certManager,
-      instance.httpClient,
-      instance.config
-    );
+    await instance.initPromise;
     return instance;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,7 +67,11 @@ export class WeChatPay {
     httpClient: HttpClient,
     config: any
   ): Promise<void> {
-    if (config.skipFetchPlatformCertificates) {
+    const shouldForceFetch = Boolean(config.forceFetchPlatformCertificates);
+    const shouldSkipByOption = Boolean(config.skipFetchPlatformCertificates);
+    const shouldSkipByPublicKey = Boolean(config.paymentPublicKey && config.publicKeyId);
+
+    if (!shouldForceFetch && (shouldSkipByOption || shouldSkipByPublicKey)) {
       return;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ export class WeChatPay {
   public readonly h5: H5Payment;
   public readonly webhook: Webhook;
   private readonly httpClient: HttpClient;
+  private readonly certManager: CertificateManager;
 
   constructor(options: any) {
     const config = loadConfig(options);
@@ -35,6 +36,7 @@ export class WeChatPay {
 
     this.config = config;
     this.httpClient = httpClient;
+    this.certManager = certManager;
     this.native = new NativePayment(httpClient, this);
     this.jsapi = new JSAPIPayment(httpClient, this);
     this.app = new AppPayment(httpClient, this);
@@ -64,6 +66,10 @@ export class WeChatPay {
     httpClient: HttpClient,
     config: any
   ): Promise<void> {
+    if (config.skipFetchPlatformCertificates) {
+      return;
+    }
+
     await certManager.fetchCertificates(() =>
       httpClient.request<CertificateAPIResponse>('GET', '/v3/certificates', undefined, true)
     );
@@ -72,8 +78,8 @@ export class WeChatPay {
   public static async initialize(options: any): Promise<WeChatPay> {
     const instance = new WeChatPay(options);
     await instance.initializeCertificates(
-      (instance as any).certManager,
-      (instance as any).httpClient,
+      instance.certManager,
+      instance.httpClient,
       instance.config
     );
     return instance;

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,10 +68,9 @@ export class WeChatPay {
     config: any
   ): Promise<void> {
     const shouldForceFetch = Boolean(config.forceFetchPlatformCertificates);
-    const shouldSkipByOption = Boolean(config.skipFetchPlatformCertificates);
     const shouldSkipByPublicKey = Boolean(config.paymentPublicKey && config.publicKeyId);
 
-    if (!shouldForceFetch && (shouldSkipByOption || shouldSkipByPublicKey)) {
+    if (!shouldForceFetch && shouldSkipByPublicKey) {
       return;
     }
 

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -7,6 +7,7 @@ export interface WeChatPayConfig {
   paymentPublicKey?: Buffer | string;
   publicKeyId?: string;
   skipFetchPlatformCertificates?: boolean;
+  forceFetchPlatformCertificates?: boolean;
   notifyUrl?: string;
   baseUrl?: string;
   debug?: boolean;

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -6,6 +6,7 @@ export interface WeChatPayConfig {
   publicKey: Buffer | string;
   paymentPublicKey?: Buffer | string;
   publicKeyId?: string;
+  skipFetchPlatformCertificates?: boolean;
   notifyUrl?: string;
   baseUrl?: string;
   debug?: boolean;

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -6,7 +6,6 @@ export interface WeChatPayConfig {
   publicKey: Buffer | string;
   paymentPublicKey?: Buffer | string;
   publicKeyId?: string;
-  skipFetchPlatformCertificates?: boolean;
   forceFetchPlatformCertificates?: boolean;
   notifyUrl?: string;
   baseUrl?: string;

--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+vi.mock('@peculiar/x509', () => ({
+  X509Certificate: class {
+    serialNumber = 'mock_serial_no';
+  }
+}));
+
+import WeChatPay from '../../src/index';
+import { CertificateManager } from '../../src/core/cert-manager';
+import { createMockConfig } from '../utils/test-helpers';
+
+describe('WeChatPay initialization', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should fetch platform certificates by default', async () => {
+    const fetchCertificatesSpy = vi
+      .spyOn(CertificateManager.prototype, 'fetchCertificates')
+      .mockResolvedValue();
+
+    new WeChatPay({
+      config: createMockConfig()
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(fetchCertificatesSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should skip fetching platform certificates when skipFetchPlatformCertificates is true', async () => {
+    const fetchCertificatesSpy = vi
+      .spyOn(CertificateManager.prototype, 'fetchCertificates')
+      .mockResolvedValue();
+
+    new WeChatPay({
+      config: createMockConfig({
+        skipFetchPlatformCertificates: true
+      })
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(fetchCertificatesSpy).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -28,6 +28,19 @@ describe('WeChatPay initialization', () => {
     expect(fetchCertificatesSpy).toHaveBeenCalledTimes(1);
   });
 
+
+  it('should only fetch platform certificates once when using static initialize', async () => {
+    const fetchCertificatesSpy = vi
+      .spyOn(CertificateManager.prototype, 'fetchCertificates')
+      .mockResolvedValue();
+
+    await WeChatPay.initialize({
+      config: createMockConfig()
+    });
+
+    expect(fetchCertificatesSpy).toHaveBeenCalledTimes(1);
+  });
+
   it('should skip fetching platform certificates when skipFetchPlatformCertificates is true', async () => {
     const fetchCertificatesSpy = vi
       .spyOn(CertificateManager.prototype, 'fetchCertificates')

--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -40,21 +40,6 @@ describe('WeChatPay initialization', () => {
     expect(fetchCertificatesSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('should skip fetching platform certificates when skipFetchPlatformCertificates is true', async () => {
-    const fetchCertificatesSpy = vi
-      .spyOn(CertificateManager.prototype, 'fetchCertificates')
-      .mockResolvedValue();
-
-    new WeChatPay({
-      config: createMockConfig({
-        skipFetchPlatformCertificates: true
-      })
-    });
-
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(fetchCertificatesSpy).not.toHaveBeenCalled();
-  });
-
   it('should skip fetching by default when paymentPublicKey and publicKeyId are provided', async () => {
     const fetchCertificatesSpy = vi
       .spyOn(CertificateManager.prototype, 'fetchCertificates')

--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -28,7 +28,6 @@ describe('WeChatPay initialization', () => {
     expect(fetchCertificatesSpy).toHaveBeenCalledTimes(1);
   });
 
-
   it('should only fetch platform certificates once when using static initialize', async () => {
     const fetchCertificatesSpy = vi
       .spyOn(CertificateManager.prototype, 'fetchCertificates')
@@ -54,5 +53,38 @@ describe('WeChatPay initialization', () => {
 
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(fetchCertificatesSpy).not.toHaveBeenCalled();
+  });
+
+  it('should skip fetching by default when paymentPublicKey and publicKeyId are provided', async () => {
+    const fetchCertificatesSpy = vi
+      .spyOn(CertificateManager.prototype, 'fetchCertificates')
+      .mockResolvedValue();
+
+    new WeChatPay({
+      config: createMockConfig({
+        paymentPublicKey: 'test_payment_public_key',
+        publicKeyId: 'PUB_KEY_ID_xxx'
+      })
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(fetchCertificatesSpy).not.toHaveBeenCalled();
+  });
+
+  it('should force fetching when forceFetchPlatformCertificates is true', async () => {
+    const fetchCertificatesSpy = vi
+      .spyOn(CertificateManager.prototype, 'fetchCertificates')
+      .mockResolvedValue();
+
+    new WeChatPay({
+      config: createMockConfig({
+        paymentPublicKey: 'test_payment_public_key',
+        publicKeyId: 'PUB_KEY_ID_xxx',
+        forceFetchPlatformCertificates: true
+      })
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(fetchCertificatesSpy).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
### Motivation

- 新商户可能只启用了微信支付公钥验签，初始化时调用 `/v3/certificates` 会返回 404 导致 SDK 初始化失败。 
- 需要一个显式配置来允许在初始化时跳过拉取平台证书以支持只用公钥的新商户。 

### Description

- 在配置类型中新增 `skipFetchPlatformCertificates?: boolean`，用于控制是否跳过初始化时拉取平台证书。 
- 在 `WeChatPay` 实例中持久化 `certManager` 并在初始化流程中加入判断：当 `config.skipFetchPlatformCertificates` 为 `true` 时直接返回不请求 `/v3/certificates`。 
- 修复 `WeChatPay.initialize` 使用实例属性 `instance.certManager` / `instance.httpClient` 的访问方式以替代 `as any` 强转。 
- 补充单元测试覆盖默认会拉取证书和开启 `skipFetchPlatformCertificates` 后不拉取的两种路径，并更新 `README.md` 与文档 `docs/*` 的示例/类型说明。 

### Testing

- 运行单元测试 `npm test`（Vitest）所有测试通过。 
- 构建验证 `npm run build` 成功（TypeScript 编译通过）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b00e039d748321bdfe678016ed63ff)